### PR TITLE
Nested map with String-type key in parent map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>co.nstant.in</groupId>
 	<artifactId>cbor</artifactId>
-	<version>0.4</version>
+	<version>0.4.1</version>
 	<name>CBOR for Java</name>
 	<description>Java implementation of RFC 7049: Concise Binary Object Representation (CBOR)</description>
 	<url>https://github.com/c-rack/cbor-java</url>
@@ -32,6 +32,16 @@
 			<name>Constantin Rack</name>
 			<email>constantin@rack.li</email>
 			<url>http://co.nstant.in/</url>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>Europe/Berlin</timezone>
+		</developer>
+		<developer>
+			<id>marandus</id>
+			<name>Thomas Rix</name>
+			<email>rix@decoit.de</email>
+			<url>http://www.decoit.de/</url>
 			<roles>
 				<role>developer</role>
 			</roles>

--- a/src/main/java/co/nstant/in/cbor/builder/MapBuilder.java
+++ b/src/main/java/co/nstant/in/cbor/builder/MapBuilder.java
@@ -104,6 +104,12 @@ public class MapBuilder<T extends AbstractBuilder<?>> extends
         return new MapBuilder<>(this, nestedMap);
     }
 
+	public MapBuilder<MapBuilder<T>> putMap(String key) {
+        Map nestedMap = new Map();
+        put(convert(key), nestedMap);
+        return new MapBuilder<>(this, nestedMap);
+    }
+
     public T end() {
         return getParent();
     }

--- a/src/main/java/co/nstant/in/cbor/encoder/HalfPrecisionFloatEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/HalfPrecisionFloatEncoder.java
@@ -21,7 +21,7 @@ public class HalfPrecisionFloatEncoder extends AbstractEncoder<HalfPrecisionFloa
 	}
 
 	/**
-	 * @see http://stackoverflow.com/a/6162687
+	 * @see <a href="http://stackoverflow.com/a/6162687">Stack Overflow</a>
 	 */
 
 	// returns all higher 16 bits as 0 for all results

--- a/src/test/java/co/nstant/in/cbor/builder/MapBuilderTest.java
+++ b/src/test/java/co/nstant/in/cbor/builder/MapBuilderTest.java
@@ -33,12 +33,14 @@ public class MapBuilderTest {
                         .put("12", "value")
                         .putMap(13)
                         .end()
+						.putMap("14")
+						.end()
                         .end()
                         .build();
         assertEquals(1, dataItems.size());
         assertTrue(dataItems.get(0) instanceof Map);
         Map map = (Map) dataItems.get(0);
-        assertEquals(14, map.getKeys().size());
+        assertEquals(15, map.getKeys().size());
     }
 
 }


### PR DESCRIPTION
I added a method to MapBuilder that puts a nested Map inside using a String-type key:
```java
    MapBuilder.putMap("mykey")
```

Updated pom.xml to version 0.4.1 to prevent conflicts with previous version.

HalfPrecisionFloatEncoder.java contained a Javadoc error that made the build fail on my system, corrected that. Now it is building fine.