### PR TITLE
MapBuilder additions and rework of data item tagging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>co.nstant.in</groupId>
 	<artifactId>cbor</artifactId>
-	<version>0.4.2</version>
+	<version>0.5</version>
 	<name>CBOR for Java</name>
 	<description>Java implementation of RFC 7049: Concise Binary Object Representation (CBOR)</description>
 	<url>https://github.com/c-rack/cbor-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>co.nstant.in</groupId>
 	<artifactId>cbor</artifactId>
-	<version>0.4.1</version>
+	<version>0.4.2</version>
 	<name>CBOR for Java</name>
 	<description>Java implementation of RFC 7049: Concise Binary Object Representation (CBOR)</description>
 	<url>https://github.com/c-rack/cbor-java</url>

--- a/src/main/java/co/nstant/in/cbor/CborDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/CborDecoder.java
@@ -17,6 +17,7 @@ import co.nstant.in.cbor.decoder.UnicodeStringDecoder;
 import co.nstant.in.cbor.decoder.UnsignedIntegerDecoder;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.MajorType;
+import co.nstant.in.cbor.model.Tag;
 
 /**
  * Decoder for the CBOR format based.
@@ -57,7 +58,7 @@ public class CborDecoder {
 
 	/**
 	 * Convenience method to decode a byte array directly.
-	 * 
+	 *
 	 * @param bytes
 	 *            the CBOR encoded data
 	 * @return a list of {@link DataItem}s
@@ -70,7 +71,7 @@ public class CborDecoder {
 
 	/**
 	 * Decode the {@link InputStream} to a list of {@link DataItem}s.
-	 * 
+	 *
 	 * @return the list of {@link DataItem}s
 	 * @throws CborException
 	 *             if decoding failed
@@ -87,7 +88,7 @@ public class CborDecoder {
 	/**
 	 * Streaming decoding of an input stream. On each decoded DataItem, the
 	 * callback listener is invoked.
-	 * 
+	 *
 	 * @param dataItemListener
 	 *            the callback listener
 	 * @throws CborException
@@ -104,7 +105,7 @@ public class CborDecoder {
 
 	/**
 	 * Decodes exactly one DataItem from the input stream.
-	 * 
+	 *
 	 * @return a {@link DataItem} or null if end of stream has reached.
 	 * @throws CborException
 	 *             if decoding failed
@@ -135,7 +136,12 @@ public class CborDecoder {
 		case SPECIAL:
 			return specialDecoder.decode(symbol);
 		case TAG:
-			return tagDecoder.decode(symbol);
+			Tag tagDi = tagDecoder.decode(symbol);
+			DataItem nextDi = decodeNext();
+			nextDi.setTag(tagDi);
+
+			return nextDi;
+			//return tagDecoder.decode(symbol);
 		default:
 			throw new CborException("Not implemented major type " + symbol);
 		}

--- a/src/main/java/co/nstant/in/cbor/CborEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/CborEncoder.java
@@ -59,7 +59,7 @@ public class CborEncoder {
 
 	/**
 	 * Encode a list of {@link DataItem}s, also known as a stream.
-	 * 
+	 *
 	 * @param dataItems
 	 *            a list of {@link DataItem}s
 	 * @throws CborException
@@ -74,7 +74,7 @@ public class CborEncoder {
 
 	/**
 	 * Encode a single {@link DataItem}.
-	 * 
+	 *
 	 * @param dataItem
 	 *            the {@link DataItem} to encode. If null, encoder encodes a
 	 *            {@link SimpleValue} NULL value.
@@ -86,6 +86,12 @@ public class CborEncoder {
 		if (dataItem == null) {
 			dataItem = SimpleValue.NULL;
 		}
+
+		if(dataItem.hasTag()) {
+			Tag tagDi = dataItem.getTag();
+			tagEncoder.encode(tagDi);
+		}
+
 		switch (dataItem.getMajorType()) {
 		case UNSIGNED_INTEGER:
 			unsignedIntegerEncoder.encode((UnsignedInteger) dataItem);

--- a/src/main/java/co/nstant/in/cbor/builder/MapBuilder.java
+++ b/src/main/java/co/nstant/in/cbor/builder/MapBuilder.java
@@ -79,7 +79,13 @@ public class MapBuilder<T extends AbstractBuilder<?>> extends
         return this;
     }
 
-    public ArrayBuilder<MapBuilder<T>> putArray(long key) {
+    public ArrayBuilder<MapBuilder<T>> putArray(DataItem key) {
+        Array array = new Array();
+        put(key, array);
+        return new ArrayBuilder<>(this, array);
+    }
+
+	public ArrayBuilder<MapBuilder<T>> putArray(long key) {
         Array array = new Array();
         put(convert(key), array);
         return new ArrayBuilder<>(this, array);
@@ -91,14 +97,34 @@ public class MapBuilder<T extends AbstractBuilder<?>> extends
         return new ArrayBuilder<>(this, array);
     }
 
-    public ArrayBuilder<MapBuilder<T>> startArray(String key) {
+    public ArrayBuilder<MapBuilder<T>> startArray(DataItem key) {
+        Array array = new Array();
+        array.setChunked(true);
+        put(key, array);
+        return new ArrayBuilder<>(this, array);
+    }
+
+	public ArrayBuilder<MapBuilder<T>> startArray(long key) {
         Array array = new Array();
         array.setChunked(true);
         put(convert(key), array);
         return new ArrayBuilder<>(this, array);
     }
 
-    public MapBuilder<MapBuilder<T>> putMap(long key) {
+	public ArrayBuilder<MapBuilder<T>> startArray(String key) {
+        Array array = new Array();
+        array.setChunked(true);
+        put(convert(key), array);
+        return new ArrayBuilder<>(this, array);
+    }
+
+    public MapBuilder<MapBuilder<T>> putMap(DataItem key) {
+        Map nestedMap = new Map();
+        put(key, nestedMap);
+        return new MapBuilder<>(this, nestedMap);
+    }
+
+	public MapBuilder<MapBuilder<T>> putMap(long key) {
         Map nestedMap = new Map();
         put(convert(key), nestedMap);
         return new MapBuilder<>(this, nestedMap);

--- a/src/main/java/co/nstant/in/cbor/model/Array.java
+++ b/src/main/java/co/nstant/in/cbor/model/Array.java
@@ -23,19 +23,20 @@ public class Array extends ChunkableDataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object instanceof Array) {
-            Array other = (Array) object;
-            return objects.equals(other.objects);
-        }
+        if (super.equals(object)) {
+			if (object instanceof Array) {
+				Array other = (Array) object;
+				return objects.equals(other.objects);
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        return objects.hashCode();
+		int hash = super.hashCode();
+		hash += objects.hashCode();
+		return hash;
     }
 
     @Override

--- a/src/main/java/co/nstant/in/cbor/model/ByteString.java
+++ b/src/main/java/co/nstant/in/cbor/model/ByteString.java
@@ -25,19 +25,20 @@ public class ByteString extends ChunkableDataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object instanceof ByteString) {
-            ByteString other = (ByteString) object;
-            return Arrays.equals(bytes, other.bytes);
-        }
+        if (super.equals(object)) {
+			if (object instanceof ByteString) {
+				ByteString other = (ByteString) object;
+				return Arrays.equals(bytes, other.bytes);
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(bytes);
+		int hash = super.hashCode();
+		hash += Arrays.hashCode(bytes);
+		return hash;
     }
 
 }

--- a/src/main/java/co/nstant/in/cbor/model/DataItem.java
+++ b/src/main/java/co/nstant/in/cbor/model/DataItem.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 public class DataItem {
 
     private final MajorType majorType;
+	private Tag tag;
 
     protected DataItem(MajorType majorType) {
         this.majorType = majorType;
@@ -14,6 +15,60 @@ public class DataItem {
     public MajorType getMajorType() {
         return majorType;
     }
+
+	public void setTag(long tag) {
+		if(tag < 0) {
+			throw new IllegalArgumentException("tag number must be 0 or greater");
+		}
+
+		this.tag = new Tag(tag);
+	}
+
+	public void setTag(Tag tag) {
+		Objects.requireNonNull(tag, "tag is null");
+		this.tag = tag;
+	}
+
+	public void removeTag() {
+		this.tag = null;
+	}
+
+	public Tag getTag() {
+		return this.tag;
+	}
+
+	public boolean hasTag() {
+		return (this.tag != null);
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if(this == object) {
+			return true;
+		}
+
+		if(object instanceof DataItem) {
+			DataItem otherDi = (DataItem) object;
+			if(this.tag != null) {
+				if(this.tag.equals(otherDi.getTag()) && this.majorType == otherDi.getMajorType()) {
+					return true;
+				}
+			}
+			else {
+				if(otherDi.getTag() == null && this.majorType == otherDi.getMajorType()) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = Objects.hashCode(this.tag);
+		return hash;
+	}
 
     protected void assertTrue(boolean condition, String message) {
         if (!condition) {

--- a/src/main/java/co/nstant/in/cbor/model/DoublePrecisionFloat.java
+++ b/src/main/java/co/nstant/in/cbor/model/DoublePrecisionFloat.java
@@ -15,19 +15,20 @@ public class DoublePrecisionFloat extends Special {
 
 	@Override
 	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (object instanceof DoublePrecisionFloat) {
-			DoublePrecisionFloat other = (DoublePrecisionFloat) object;
-			return value == other.value;
+		if (super.equals(object)) {
+			if (object instanceof DoublePrecisionFloat) {
+				DoublePrecisionFloat other = (DoublePrecisionFloat) object;
+				return value == other.value;
+			}
 		}
 		return false;
 	}
 
 	@Override
 	public int hashCode() {
-		return Double.valueOf(value).hashCode();
+		int hash = super.hashCode();
+		hash += Double.valueOf(value).hashCode();
+		return hash;
 	}
 
 	@Override

--- a/src/main/java/co/nstant/in/cbor/model/Map.java
+++ b/src/main/java/co/nstant/in/cbor/model/Map.java
@@ -46,19 +46,20 @@ public class Map extends ChunkableDataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object instanceof Map) {
-            Map other = (Map) object;
-            return map.equals(other.map);
-        }
+        if (super.equals(object)) {
+			if (object instanceof Map) {
+				Map other = (Map) object;
+				return map.equals(other.map);
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        return map.hashCode();
+		int hash = super.hashCode();
+		hash += map.hashCode();
+		return hash;
     }
 
     @Override

--- a/src/main/java/co/nstant/in/cbor/model/Number.java
+++ b/src/main/java/co/nstant/in/cbor/model/Number.java
@@ -17,19 +17,20 @@ public abstract class Number extends DataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object instanceof Number) {
-            Number other = (Number) object;
-            return value.equals(other.value);
-        }
+        if (super.equals(object)) {
+			if (object instanceof Number) {
+				Number other = (Number) object;
+				return value.equals(other.value);
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+		int hash = super.hashCode();
+		hash += value.hashCode();
+		return hash;
     }
 
     @Override

--- a/src/main/java/co/nstant/in/cbor/model/SimpleValue.java
+++ b/src/main/java/co/nstant/in/cbor/model/SimpleValue.java
@@ -36,19 +36,20 @@ public class SimpleValue extends Special {
 
 	@Override
 	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (object instanceof SimpleValue) {
-			SimpleValue other = (SimpleValue) object;
-			return value == other.value;
+		if (super.equals(object)) {
+			if (object instanceof SimpleValue) {
+				SimpleValue other = (SimpleValue) object;
+				return value == other.value;
+			}
 		}
 		return false;
 	}
 
 	@Override
 	public int hashCode() {
-		return value;
+		int hash = super.hashCode();
+		hash += value;
+		return hash;
 	}
 
 }

--- a/src/main/java/co/nstant/in/cbor/model/Tag.java
+++ b/src/main/java/co/nstant/in/cbor/model/Tag.java
@@ -15,16 +15,20 @@ public class Tag extends DataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (object instanceof Tag) {
-            Tag other = (Tag) object;
-            return value == other.value;
-        }
+		if (super.equals(object)) {
+			if (object instanceof Tag) {
+				Tag other = (Tag) object;
+				return value == other.value;
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Long.valueOf(value).hashCode();
+		int hash = super.hashCode();
+		hash += Long.valueOf(value).hashCode();
+		return hash;
     }
 
 }

--- a/src/main/java/co/nstant/in/cbor/model/UnicodeString.java
+++ b/src/main/java/co/nstant/in/cbor/model/UnicodeString.java
@@ -24,24 +24,29 @@ public class UnicodeString extends ChunkableDataItem {
 
     @Override
     public boolean equals(Object object) {
-        if (object instanceof UnicodeString) {
-            UnicodeString other = (UnicodeString) object;
-            if (string == null) {
-                return other.string == null;
-            } else {
-                return string.equals(other.string);
-            }
-        }
+		if (super.equals(object)) {
+			if (object instanceof UnicodeString) {
+				UnicodeString other = (UnicodeString) object;
+				if (string == null) {
+					return other.string == null;
+				} else {
+					return string.equals(other.string);
+				}
+			}
+		}
         return false;
     }
 
     @Override
     public int hashCode() {
-        if (string == null) {
-            return 0;
-        } else {
-            return string.hashCode();
-        }
+		int hash = 0;
+
+		if (string != null) {
+			hash = super.hashCode();
+			hash += string.hashCode();
+		}
+
+		return hash;
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/EncoderDecoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/EncoderDecoderTest.java
@@ -24,4 +24,22 @@ public class EncoderDecoderTest {
 		Assert.assertEquals(a, object);
 	}
 
+	@Test
+	public void testTagging() throws CborException {
+		UnsignedInteger a = new UnsignedInteger(1);
+		NegativeInteger x = new NegativeInteger(-2);
+
+		a.setTag(1);
+
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		CborEncoder encoder = new CborEncoder(byteArrayOutputStream);
+		encoder.encode(a);
+		encoder.encode(x);
+		byte[] bytes = byteArrayOutputStream.toByteArray();
+		DataItem object = CborDecoder.decode(bytes).get(0);
+		Assert.assertEquals(a, object);
+		Assert.assertTrue(object.hasTag());
+		Assert.assertEquals(1L, object.getTag().getValue());
+	}
+
 }

--- a/src/test/java/co/nstant/in/cbor/builder/MapBuilderTest.java
+++ b/src/test/java/co/nstant/in/cbor/builder/MapBuilderTest.java
@@ -11,6 +11,7 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 public class MapBuilderTest {
 
@@ -35,12 +36,20 @@ public class MapBuilderTest {
                         .end()
 						.putMap("14")
 						.end()
+						.putMap(new UnsignedInteger(15))
+						.end()
+						.putArray(16)
+                        .end()
+						.putArray("17")
+						.end()
+						.putArray(new UnsignedInteger(18))
+						.end()
                         .end()
                         .build();
         assertEquals(1, dataItems.size());
         assertTrue(dataItems.get(0) instanceof Map);
         Map map = (Map) dataItems.get(0);
-        assertEquals(15, map.getKeys().size());
+        assertEquals(19, map.getKeys().size());
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example12Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example12Test.java
@@ -37,11 +37,10 @@ public class Example12Test {
 				new byte[] { (byte) 0xc2, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00 });
 		CborDecoder decoder = new CborDecoder(byteArrayInputStream);
-		DataItem a = decoder.decodeNext();
 		DataItem b = decoder.decodeNext();
 
-		Assert.assertTrue(a instanceof Tag);
-		Tag tag = (Tag) a;
+		Assert.assertTrue(b.hasTag());
+		Tag tag = b.getTag();
 		Assert.assertEquals(2, tag.getValue());
 
 		Assert.assertTrue(b instanceof ByteString);

--- a/src/test/java/co/nstant/in/cbor/examples/Example14Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example14Test.java
@@ -37,11 +37,10 @@ public class Example14Test {
 				new byte[] { (byte) 0xc3, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00 });
 		CborDecoder decoder = new CborDecoder(byteArrayInputStream);
-		DataItem a = decoder.decodeNext();
 		DataItem b = decoder.decodeNext();
 
-		Assert.assertTrue(a instanceof Tag);
-		Tag tag = (Tag) a;
+		Assert.assertTrue(b.hasTag());
+		Tag tag = b.getTag();
 		Assert.assertEquals(3, tag.getValue());
 
 		Assert.assertTrue(b instanceof ByteString);

--- a/src/test/java/co/nstant/in/cbor/examples/Example48Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example48Test.java
@@ -13,18 +13,25 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnicodeString;
 
 /**
  * 0("2013-03-21T20:04:00Z") -> 0xc074323031332d30332d32315432303a30343a30305a
  */
 public class Example48Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(0)
-			.add("2013-03-21T20:04:00Z").build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc0, 0x74,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc0, 0x74,
 			0x32, 0x30, 0x31, 0x33, 0x2d, 0x30, 0x33, 0x2d, 0x32, 0x31, 0x54,
 			0x32, 0x30, 0x3a, 0x30, 0x34, 0x3a, 0x30, 0x30, 0x5a };
+
+	public Example48Test() {
+		DataItem di = new UnicodeString("2013-03-21T20:04:00Z");
+		di.setTag(0);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {

--- a/src/test/java/co/nstant/in/cbor/examples/Example49Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example49Test.java
@@ -13,17 +13,24 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 /**
  * 1(1363896240) -> 0xc11a514b67b0
  */
 public class Example49Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(1)
-			.add(1363896240).build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc1, 0x1a,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc1, 0x1a,
 			0x51, 0x4b, 0x67, (byte) 0xb0 };
+
+	public Example49Test() {
+		DataItem di = new UnsignedInteger(1363896240);
+		di.setTag(1);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {

--- a/src/test/java/co/nstant/in/cbor/examples/Example50Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example50Test.java
@@ -13,18 +13,25 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.DoublePrecisionFloat;
 
 /**
  * 1(1363896240.5) -> 0xc1fb41d452d9ec200000
  */
 public class Example50Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(1)
-			.add(1363896240.5).build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc1,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xc1,
 			(byte) 0xfb, 0x41, (byte) 0xd4, 0x52, (byte) 0xd9, (byte) 0xec,
 			0x20, 0x00, 0x00 };
+
+	public Example50Test() {
+		DataItem di = new DoublePrecisionFloat(1363896240.5);
+		di.setTag(1);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {

--- a/src/test/java/co/nstant/in/cbor/examples/Example51Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example51Test.java
@@ -12,6 +12,7 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 
 /**
@@ -19,11 +20,17 @@ import co.nstant.in.cbor.model.DataItem;
  */
 public class Example51Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(23)
-			.add(new byte[] { 0x01, 0x02, 0x03, 0x04 }).build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd7, 0x44,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd7, 0x44,
 			0x01, 0x02, 0x03, 0x04 };
+
+	public Example51Test() {
+		DataItem di = new ByteString(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+		di.setTag(23);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {
@@ -39,6 +46,7 @@ public class Example51Test {
 		CborDecoder decoder = new CborDecoder(inputStream);
 		List<DataItem> dataItems = decoder.decode();
 		Assert.assertArrayEquals(VALUE.toArray(), dataItems.toArray());
+
 	}
 
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example52Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example52Test.java
@@ -12,6 +12,7 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 
 /**
@@ -19,11 +20,17 @@ import co.nstant.in.cbor.model.DataItem;
  */
 public class Example52Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(24)
-			.add(new byte[] { 0x64, 0x49, 0x45, 0x54, 0x46 }).build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd8, 0x18,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd8, 0x18,
 			0x45, 0x64, 0x49, 0x45, 0x54, 0x46 };
+
+	public Example52Test() {
+		DataItem di = new ByteString(new byte[] { 0x64, 0x49, 0x45, 0x54, 0x46 });
+		di.setTag(24);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {

--- a/src/test/java/co/nstant/in/cbor/examples/Example53Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example53Test.java
@@ -13,6 +13,7 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnicodeString;
 
 /**
  * 32("http://www.example.com") ->
@@ -20,13 +21,19 @@ import co.nstant.in.cbor.model.DataItem;
  */
 public class Example53Test {
 
-	private static final List<DataItem> VALUE = new CborBuilder().addTag(32)
-			.add("http://www.example.com").build();
+	private final List<DataItem> VALUE;
 
-	private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd8, 0x20,
+	private final byte[] ENCODED_VALUE = new byte[] { (byte) 0xd8, 0x20,
 			0x76, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x77, 0x77, 0x77,
 			0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f,
 			0x6d };
+
+	public Example53Test() {
+		DataItem di = new UnicodeString("http://www.example.com");
+		di.setTag(32);
+
+		VALUE = new CborBuilder().add(di).build();
+	}
 
 	@Test
 	public void shouldEncode() throws CborException {

--- a/src/test/java/co/nstant/in/cbor/model/DataItemTest.java
+++ b/src/test/java/co/nstant/in/cbor/model/DataItemTest.java
@@ -1,6 +1,7 @@
 package co.nstant.in.cbor.model;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class DataItemTest {
 
@@ -8,5 +9,59 @@ public class DataItemTest {
     public void shouldThrowNullPointerException() {
         new DataItem(null);
     }
+
+	@Test
+	public void testSetTag_Long() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(1);
+		assertNotNull(di.getTag());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetTag_Long_negative() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(-1);
+	}
+
+	@Test
+	public void testSetTag_Tag() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(new Tag(1));
+		assertNotNull(di.getTag());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testSetTag_Tag_null() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(null);
+	}
+
+	@Test
+	public void testGetTag() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(new Tag(1));
+
+		Tag t = di.getTag();
+		assertEquals(1L, t.getValue());
+	}
+
+	@Test
+	public void testHasTag() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		assertFalse(di.hasTag());
+
+		di.setTag(new Tag(1));
+		assertTrue(di.hasTag());
+	}
+
+	@Test
+	public void testRemoveTag() {
+		DataItem di = new DataItem(MajorType.UNSIGNED_INTEGER);
+		di.setTag(new Tag(1));
+		assertNotNull(di.getTag());
+
+		di.removeTag();
+		assertNull(di.getTag());
+	}
 
 }


### PR DESCRIPTION
The first commit contains small changes to the MapBuilder that make working with it more comfortable. You can now put Arrays and Maps into a MapBuilder by using any DataItem as key. This updated version in pom.xml to 0.4.2.

The second commit contains a rework of the tagging mechanic and pushes the version to 0.5 because of the massive changes. The old version did not allow tagging of Map keys or values, because you needed two different DataItem instances to achieve that. That was something that the current API was unable to do. Because of that I did a complete rework of the data item tagging. The old method is still in place for CborEncoder backward compatibility but the CborDecoder results will differ from the results before this rework.

The new mechanic of tagging allows a data item of type Tag to be added to any data item. RFC 7049 clearly states that any data item may be tagged, even other tags (see chapter 2.4.). To achieve this the following methods were added to DataItem, their names should be self-explanatory:

```java
DataItem.setTag(Tag)
DataItem.setTag(long)
DataItem.removeTag()
DataItem.getTag()
DataItem.hasTag()
```

Additionally the existing equals() and hashCode() methods of all DataItem sub classes have been updated to take the tag into account if present. If no tag is present, they will show the same behavior as before.

The CborEncoder was changed to first check if the provided DataItem has a tag. If it has, the tag is encoded first followed by the actual data item. If it has no tag, the first step is skipped and everything works as before. This is done by a recursive mechanic which retains order of tags for nested tags. The last tag (the one that is not tagged itself) will be encoded first follow by the one that was tagged by it etc etc. This is 100% backward compatible to the old mechanic and requires no changes to existing code.

The new version of CborDecoder however is NOT backward compatible. If it encounters a tag during decoding it directly reads the next DataItem, adds the tag to it by using ´DataItem.setTag()` and then returns the tagged data item. This means that a DataItem structure created by the new CborDecoder will never contain any data item of type Tag. All tags are contained in the items tagged by them. This mechanic works recursively as well to retain order of nested tags.

The examples have been adjusted to reflect the new style of data item tagging.

In my opinion this was the most elegant and intuitive way to allow tagging of any data item. If you do not like the change please let me know and I would provide you another pull request with just the MapBuilder changes mentioned above, excluding the tagging changes.