### PR TITLE
Solution: remove the `clone()`

### DIFF
--- a/src/main/java/co/nstant/in/cbor/model/ByteString.java
+++ b/src/main/java/co/nstant/in/cbor/model/ByteString.java
@@ -11,7 +11,7 @@ public class ByteString extends ChunkableDataItem {
         if (bytes == null) {
             this.bytes = null;
         } else {
-            this.bytes = bytes.clone();
+            this.bytes = bytes;
         }
     }
 
@@ -19,7 +19,7 @@ public class ByteString extends ChunkableDataItem {
         if (bytes == null) {
             return null;
         } else {
-            return bytes.clone();
+            return bytes;
         }
     }
 

--- a/src/test/java/co/nstant/in/cbor/model/ByteStringTest.java
+++ b/src/test/java/co/nstant/in/cbor/model/ByteStringTest.java
@@ -45,4 +45,11 @@ public class ByteStringTest extends AbstractDataItemTest {
         assertEquals(byteString.hashCode(), superClass.hashCode() ^ Arrays.hashCode(bytes));
     }
 
+    @Test
+    public void shouldNotClone() {
+        byte[] bytes = "see issue #18".getBytes();
+        ByteString byteString = new ByteString(bytes);
+        assertEquals(byteString.getBytes(), bytes);
+    }
+
 }


### PR DESCRIPTION
Fixes #18

The call to `clone()` was originally introduced to pass the PMD checks.
However, the PMD checks seem to be broken for a while, so we can safely
change this.

Additionally, we add a test that ensures that cloning will not be
re-introduced later.