### PR TITLE
Microej4port

### DIFF
--- a/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
@@ -3,7 +3,7 @@ package co.nstant.in.cbor.decoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.io.UnsupportedEncodingException;
 
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
@@ -14,7 +14,7 @@ import co.nstant.in.cbor.model.UnicodeString;
 
 public class UnicodeStringDecoder extends AbstractDecoder<UnicodeString> {
 
-	private static final Charset UTF8 = Charset.forName("UTF8");
+	private static final String UTF8 = "UTF-8";
 
 	public UnicodeStringDecoder(CborDecoder decoder, InputStream inputStream) {
 		super(decoder, inputStream);
@@ -55,7 +55,11 @@ public class UnicodeStringDecoder extends AbstractDecoder<UnicodeString> {
 				throw new CborException("Unexpected major type " + majorType);
 			}
 		}
-		return new UnicodeString(new String(bytes.toByteArray(), UTF8));
+		try {
+			return new UnicodeString(new String(bytes.toByteArray(), UTF8));
+		} catch (UnsupportedEncodingException e) {
+			throw new CborException(e);
+		}
 	}
 
 	private UnicodeString decodeFixedLength(long length) throws CborException {
@@ -63,7 +67,11 @@ public class UnicodeStringDecoder extends AbstractDecoder<UnicodeString> {
 		for (long i = 0; i < length; i++) {
 			bytes.write(nextSymbol());
 		}
-		return new UnicodeString(new String(bytes.toByteArray(), UTF8));
+		try {
+			return new UnicodeString(new String(bytes.toByteArray(), UTF8));
+		} catch (UnsupportedEncodingException e) {
+			throw new CborException(e);
+		}
 	}
 
 }

--- a/src/main/java/co/nstant/in/cbor/encoder/UnicodeStringEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/UnicodeStringEncoder.java
@@ -1,7 +1,7 @@
 package co.nstant.in.cbor.encoder;
 
 import java.io.OutputStream;
-import java.nio.charset.Charset;
+import java.io.UnsupportedEncodingException;
 
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
@@ -11,7 +11,7 @@ import co.nstant.in.cbor.model.UnicodeString;
 
 public class UnicodeStringEncoder extends AbstractEncoder<UnicodeString> {
 
-    private static final Charset UTF8 = Charset.forName("UTF8");
+    private static final String UTF8 = "UTF-8";
 
     public UnicodeStringEncoder(CborEncoder encoder, OutputStream outputStream) {
         super(encoder, outputStream);
@@ -28,7 +28,12 @@ public class UnicodeStringEncoder extends AbstractEncoder<UnicodeString> {
         } else if (string == null) {
             encoder.encode(SimpleValue.NULL);
         } else {
-            byte[] bytes = string.getBytes(UTF8);
+            byte[] bytes;
+			try {
+				bytes = string.getBytes(UTF8);
+			} catch (UnsupportedEncodingException e) {
+				throw new CborException(e);
+			}
             encodeTypeAndLength(MajorType.UNICODE_STRING, bytes.length);
             write(bytes);
         }

--- a/src/main/java/co/nstant/in/cbor/model/Tag.java
+++ b/src/main/java/co/nstant/in/cbor/model/Tag.java
@@ -31,7 +31,7 @@ public class Tag extends DataItem {
 
     @Override
     public String toString() {
-        return String.format("Tag(%d)", value);
+        return "Tag("+value+")";
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/DatemItemListenerTest.java
+++ b/src/test/java/co/nstant/in/cbor/DatemItemListenerTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
@@ -16,19 +15,21 @@ public class DatemItemListenerTest {
 
     @Test
     public void shouldDecodeZero() throws CborException {
-        final AtomicInteger dataItems = new AtomicInteger(0);
+    	final int[] dataItems = new int[1];
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         new CborEncoder(outputStream).encode(new CborBuilder().add(1234).build());
         new CborDecoder(new ByteArrayInputStream(outputStream.toByteArray())).decode(new DataItemListener() {
 
             @Override
             public void onDataItem(DataItem dataItem) {
-                dataItems.incrementAndGet();
+                synchronized (dataItems) {
+                	++dataItems[0];	
+				}
                 assertTrue(dataItem instanceof UnsignedInteger);
             }
 
         });
-        assertEquals(1, dataItems.intValue());
+        assertEquals(1, dataItems[0]);
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/encoder/AbstractEncoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/encoder/AbstractEncoderTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
@@ -34,12 +33,12 @@ public class AbstractEncoderTest {
 
     @Test(expected = CborException.class)
     public void shouldThrowCborExceptionOnUnderlyingIoException() throws CborException {
-        final AtomicInteger counter = new AtomicInteger();
+        final int[] counter = new int[1];
         new CborEncoder(new OutputStream() {
 
             @Override
             public synchronized void write(int b) throws IOException {
-                if (counter.incrementAndGet() == 3) {
+                if (++counter[0] == 3) {
                     throw new IOException();
                 }
             }


### PR DESCRIPTION
Minor changes to make this library MicroEJ 4 compliant.
Only depends on EDC-1.2 + ej.library.eclasspath.biginteger artifact.
See http://developer.microej.com/getting-started.html