### PR TITLE
Problem: No way to reject duplicate keys in maps

### DIFF
--- a/src/main/java/co/nstant/in/cbor/CborDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/CborDecoder.java
@@ -45,6 +45,7 @@ public class CborDecoder {
     private boolean autoDecodeInfinitiveUnicodeStrings = true;
     private boolean autoDecodeRationalNumbers = true;
     private boolean autoDecodeLanguageTaggedStrings = true;
+    private boolean rejectDuplicateKeys = false;
 
     /**
      * Initialize a new decoder which reads the binary encoded data from an
@@ -271,6 +272,14 @@ public class CborDecoder {
     public void setAutoDecodeLanguageTaggedStrings(
         boolean autoDecodeLanguageTaggedStrings) {
         this.autoDecodeLanguageTaggedStrings = autoDecodeLanguageTaggedStrings;
+    }
+
+    public boolean isRejectDuplicateKeys() {
+        return rejectDuplicateKeys;
+    }
+
+    public void setRejectDuplicateKeys(boolean rejectDuplicateKeys) {
+        this.rejectDuplicateKeys = rejectDuplicateKeys;
     }
 
 }

--- a/src/main/java/co/nstant/in/cbor/decoder/MapDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/MapDecoder.java
@@ -37,6 +37,9 @@ public class MapDecoder extends AbstractDecoder<Map> {
                 if (key == null || value == null) {
                     throw new CborException("Unexpected end of stream");
                 }
+                if (decoder.isRejectDuplicateKeys() && map.get(key) != null) {
+                    throw new CborException("Duplicate key found in map");
+                }
                 map.put(key, value);
             }
         }
@@ -50,6 +53,9 @@ public class MapDecoder extends AbstractDecoder<Map> {
             DataItem value = decoder.decodeNext();
             if (key == null || value == null) {
                 throw new CborException("Unexpected end of stream");
+            }
+            if (decoder.isRejectDuplicateKeys() && map.get(key) != null) {
+                throw new CborException("Duplicate key found in map");
             }
             map.put(key, value);
         }

--- a/src/test/java/co/nstant/in/cbor/decoder/MapDecoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/decoder/MapDecoderTest.java
@@ -1,9 +1,17 @@
 package co.nstant.in.cbor.decoder;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
 import org.junit.Test;
 
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 public class MapDecoderTest {
     @Test(expected = CborException.class)
@@ -22,5 +30,33 @@ public class MapDecoderTest {
     public void shouldThrowOnIncompleteIndefiniteLengthMap() throws CborException {
         byte[] bytes = new byte[] {(byte) 0xbf, 0x61, 0x01};
         CborDecoder.decode(bytes);
+    }
+
+    @Test
+    public void shouldUseLastOfDuplicateKeysByDefault() throws CborException {
+        byte[] bytes = new byte[] {(byte)0xa2, 0x01, 0x01, 0x01, 0x02};
+        List<DataItem> decoded = CborDecoder.decode(bytes);
+        Map map = (Map)decoded.get(0);
+        assertEquals(map.getKeys().size(), 1);
+        assertEquals(map.get(new UnsignedInteger(1)), new UnsignedInteger(2));
+    }
+
+    @Test(expected = CborException.class)
+    public void shouldThrowOnDuplicateKeyIfEnabled() throws CborException {
+        byte[] bytes = new byte[] {(byte)0xa2, 0x01, 0x01, 0x01, 0x02};
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        CborDecoder decoder = new CborDecoder(bais);
+        decoder.setRejectDuplicateKeys(true);
+        decoder.decode();
+    }
+
+    @Test(expected = CborException.class)
+    public void shouldThrowInDuplicateKeyInIndefiniteLengthMapIfEnabled()
+            throws CborException {
+        byte[] bytes = new byte[] {(byte)0xbf, 0x01, 0x01, 0x01, 0x02, (byte) 0xff};
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        CborDecoder decoder = new CborDecoder(bais);
+        decoder.setRejectDuplicateKeys(true);
+        decoder.decode();
     }
 }


### PR DESCRIPTION
Solution: Add parameter to CborDecoder to control
behavior. Switches between keeping last seen value
and throwing if a duplicate key is found.