### PR TITLE
Performance and security improvements

### DIFF
--- a/src/main/java/co/nstant/in/cbor/CborDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/CborDecoder.java
@@ -285,4 +285,22 @@ public class CborDecoder {
         this.rejectDuplicateKeys = rejectDuplicateKeys;
     }
 
+    /**
+     * Sets the given amount of bytes as maximum preallocation limit for arrays in all decoders. This prevents
+     * OutOfMemory exceptions on malicious CBOR with forged fixed length items. Note that items may exceed the given
+     * size when the decoded data actually contains much data. This may be limited by using a limiting stream.
+     *
+     * @param maxSize Maximum number of bytes to preallocate in array-based items. Set to 0 to disable.
+     */
+    public void setMaxPreallocationSize(int maxSize) {
+        unsignedIntegerDecoder.setMaxPreallocationSize(maxSize);
+        negativeIntegerDecoder.setMaxPreallocationSize(maxSize);
+        byteStringDecoder.setMaxPreallocationSize(maxSize);
+        unicodeStringDecoder.setMaxPreallocationSize(maxSize);
+        arrayDecoder.setMaxPreallocationSize(maxSize);
+        mapDecoder.setMaxPreallocationSize(maxSize);
+        tagDecoder.setMaxPreallocationSize(maxSize);
+        specialDecoder.setMaxPreallocationSize(maxSize);
+    }
+
 }

--- a/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
@@ -14,6 +14,7 @@ public abstract class AbstractDecoder<T> {
 
     protected final InputStream inputStream;
     protected final CborDecoder decoder;
+    private int maxPreallocationSize;
 
     public AbstractDecoder(CborDecoder decoder, InputStream inputStream) {
         this.decoder = decoder;
@@ -115,5 +116,14 @@ public abstract class AbstractDecoder<T> {
         default:
             throw new CborException("Reserved additional information");
         }
+    }
+
+    int getPreallocationSize(long length) {
+        int len = Math.abs((int) length);
+        return maxPreallocationSize > 0 ? Math.min(maxPreallocationSize, len) : len;
+    }
+
+    public void setMaxPreallocationSize(int maxPreallocationSize) {
+        this.maxPreallocationSize = maxPreallocationSize;
     }
 }

--- a/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
@@ -11,6 +11,8 @@ import co.nstant.in.cbor.model.AdditionalInformation;
 
 public abstract class AbstractDecoder<T> {
 
+    private static final int BUFFER_SIZE = 4096;
+
     protected static final int INFINITY = -1;
 
     protected final InputStream inputStream;
@@ -66,7 +68,7 @@ public abstract class AbstractDecoder<T> {
             throw new CborException("Decoding fixed size items is limited to INTMAX");
         }
         ByteArrayOutputStream bytes = new ByteArrayOutputStream(getPreallocationSize(length));
-        final int chunkSize = 4096;
+        final int chunkSize = (int) (length > BUFFER_SIZE ? BUFFER_SIZE : length);
         int i = (int) length;
         byte[] buf = new byte[chunkSize];
         while (i > 0) {

--- a/src/main/java/co/nstant/in/cbor/decoder/ArrayDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/ArrayDecoder.java
@@ -45,7 +45,7 @@ public class ArrayDecoder extends AbstractDecoder<Array> {
     }
 
     private Array decodeFixedLength(long length) throws CborException {
-        Array array = new Array();
+        Array array = new Array(getPreallocationSize(length));
         for (long i = 0; i < length; i++) {
             DataItem dataItem = decoder.decodeNext();
             if (dataItem == null) {

--- a/src/main/java/co/nstant/in/cbor/decoder/ByteStringDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/ByteStringDecoder.java
@@ -57,7 +57,7 @@ public class ByteStringDecoder extends AbstractDecoder<ByteString> {
     }
 
     private ByteString decodeFixedLength(long length) throws CborException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream((int) length);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(getPreallocationSize(length));
         for (long i = 0; i < length; i++) {
             bytes.write(nextSymbol());
         }

--- a/src/main/java/co/nstant/in/cbor/decoder/ByteStringDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/ByteStringDecoder.java
@@ -57,11 +57,7 @@ public class ByteStringDecoder extends AbstractDecoder<ByteString> {
     }
 
     private ByteString decodeFixedLength(long length) throws CborException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream(getPreallocationSize(length));
-        for (long i = 0; i < length; i++) {
-            bytes.write(nextSymbol());
-        }
-        return new ByteString(bytes.toByteArray());
+        return new ByteString(decodeBytes(length));
     }
 
 }

--- a/src/main/java/co/nstant/in/cbor/decoder/DoublePrecisionFloatDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/DoublePrecisionFloatDecoder.java
@@ -17,21 +17,22 @@ public class DoublePrecisionFloatDecoder extends
     @Override
     public DoublePrecisionFloat decode(int initialByte) throws CborException {
         long bits = 0;
-        bits |= nextSymbol() & 0xFF;
+        byte[] symbols = nextSymbols(8);
+        bits |= symbols[0] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[1] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[2] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[3] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[4] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[5] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[6] & 0xFF;
         bits <<= 8;
-        bits |= nextSymbol() & 0xFF;
+        bits |= symbols[7] & 0xFF;
         return new DoublePrecisionFloat(Double.longBitsToDouble(bits));
     }
 

--- a/src/main/java/co/nstant/in/cbor/decoder/HalfPrecisionFloatDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/HalfPrecisionFloatDecoder.java
@@ -16,7 +16,8 @@ public class HalfPrecisionFloatDecoder extends
 
     @Override
     public HalfPrecisionFloat decode(int initialByte) throws CborException {
-        int bits = nextSymbol() << 8 | nextSymbol();
+        byte[] symbols = nextSymbols(2);
+        int bits = (symbols[0] & 0xFF) << 8 | (symbols[1] & 0xFF);
         return new HalfPrecisionFloat(toFloat(bits));
     }
 

--- a/src/main/java/co/nstant/in/cbor/decoder/MapDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/MapDecoder.java
@@ -47,7 +47,7 @@ public class MapDecoder extends AbstractDecoder<Map> {
     }
 
     private Map decodeFixedLength(long length) throws CborException {
-        Map map = new Map((int) length);
+        Map map = new Map(getPreallocationSize(length));
         for (long i = 0; i < length; i++) {
             DataItem key = decoder.decodeNext();
             DataItem value = decoder.decodeNext();

--- a/src/main/java/co/nstant/in/cbor/decoder/SinglePrecisionFloatDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/SinglePrecisionFloatDecoder.java
@@ -15,13 +15,14 @@ public class SinglePrecisionFloatDecoder extends AbstractDecoder<SinglePrecision
 	@Override
 	public SinglePrecisionFloat decode(int initialByte) throws CborException {
 		int bits = 0;
-		bits |= nextSymbol() & 0xFF;
+		byte[] symbols = nextSymbols(4);
+		bits |= symbols[0] & 0xFF;
 		bits <<= 8;
-		bits |= nextSymbol() & 0xFF;
+		bits |= symbols[1] & 0xFF;
 		bits <<= 8;
-		bits |= nextSymbol() & 0xFF;
+		bits |= symbols[2] & 0xFF;
 		bits <<= 8;
-		bits |= nextSymbol() & 0xFF;
+		bits |= symbols[3] & 0xFF;
 		return new SinglePrecisionFloat(Float.intBitsToFloat(bits));
 	}
 

--- a/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
@@ -55,11 +55,7 @@ public class UnicodeStringDecoder extends AbstractDecoder<UnicodeString> {
     }
 
     private UnicodeString decodeFixedLength(long length) throws CborException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream(getPreallocationSize(length));
-        for (long i = 0; i < length; i++) {
-            bytes.write(nextSymbol());
-        }
-        return new UnicodeString(new String(bytes.toByteArray(), StandardCharsets.UTF_8));
+        return new UnicodeString(new String(decodeBytes(length), StandardCharsets.UTF_8));
     }
 
 }

--- a/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/UnicodeStringDecoder.java
@@ -55,7 +55,7 @@ public class UnicodeStringDecoder extends AbstractDecoder<UnicodeString> {
     }
 
     private UnicodeString decodeFixedLength(long length) throws CborException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream((int) length);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(getPreallocationSize(length));
         for (long i = 0; i < length; i++) {
             bytes.write(nextSymbol());
         }

--- a/src/main/java/co/nstant/in/cbor/encoder/AbstractEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/AbstractEncoder.java
@@ -36,34 +36,34 @@ public abstract class AbstractEncoder<T> {
 	protected void encodeTypeAndLength(MajorType majorType, long length) throws CborException {
 		int symbol = majorType.getValue() << 5;
 		if (length <= 23L) {
-			write((int) (symbol | length));
+			write((byte) (symbol | length));
 		} else if (length <= 255L) {
 			symbol |= AdditionalInformation.ONE_BYTE.getValue();
-			write(symbol);
-			write((int) length);
+			write((byte) symbol,
+			      (byte) length);
 		} else if (length <= 65535L) {
 			symbol |= AdditionalInformation.TWO_BYTES.getValue();
-			write(symbol);
-			write((int) (length >> 8));
-			write((int) (length & 0xFF));
+			write((byte) symbol,
+			      (byte) (length >> 8),
+			      (byte) (length & 0xFF));
 		} else if (length <= 4294967295L) {
 			symbol |= AdditionalInformation.FOUR_BYTES.getValue();
-			write(symbol);
-			write((int) ((length >> 24) & 0xFF));
-			write((int) ((length >> 16) & 0xFF));
-			write((int) ((length >> 8) & 0xFF));
-			write((int) (length & 0xFF));
+			write((byte) symbol,
+			      (byte) ((length >> 24) & 0xFF),
+			      (byte) ((length >> 16) & 0xFF),
+			      (byte) ((length >> 8) & 0xFF),
+			      (byte) (length & 0xFF));
 		} else {
 			symbol |= AdditionalInformation.EIGHT_BYTES.getValue();
-			write(symbol);
-			write((int) ((length >> 56) & 0xFF));
-			write((int) ((length >> 48) & 0xFF));
-			write((int) ((length >> 40) & 0xFF));
-			write((int) ((length >> 32) & 0xFF));
-			write((int) ((length >> 24) & 0xFF));
-			write((int) ((length >> 16) & 0xFF));
-			write((int) ((length >> 8) & 0xFF));
-			write((int) (length & 0xFF));
+			write((byte) symbol,
+			      (byte) ((length >> 56) & 0xFF),
+			      (byte) ((length >> 48) & 0xFF),
+			      (byte) ((length >> 40) & 0xFF),
+			      (byte) ((length >> 32) & 0xFF),
+			      (byte) ((length >> 24) & 0xFF),
+			      (byte) ((length >> 16) & 0xFF),
+			      (byte) ((length >> 8) & 0xFF),
+			      (byte) (length & 0xFF));
 		}
 	}
 
@@ -74,34 +74,34 @@ public abstract class AbstractEncoder<T> {
 			write(symbol | length.intValue());
 		} else if (length.compareTo(BigInteger.valueOf(256)) == -1) {
 			symbol |= AdditionalInformation.ONE_BYTE.getValue();
-			write(symbol);
-			write(length.intValue());
+			write((byte) symbol,
+			      (byte) length.intValue());
 		} else if (length.compareTo(BigInteger.valueOf(65536L)) == -1) {
 			symbol |= AdditionalInformation.TWO_BYTES.getValue();
-			write(symbol);
 			long twoByteValue = length.longValue();
-			write((int) (twoByteValue >> 8));
-			write((int) (twoByteValue & 0xFF));
+			write((byte) symbol,
+			      (byte) (twoByteValue >> 8),
+			      (byte) (twoByteValue & 0xFF));
 		} else if (length.compareTo(BigInteger.valueOf(4294967296L)) == -1) {
 			symbol |= AdditionalInformation.FOUR_BYTES.getValue();
-			write(symbol);
 			long fourByteValue = length.longValue();
-			write((int) ((fourByteValue >> 24) & 0xFF));
-			write((int) ((fourByteValue >> 16) & 0xFF));
-			write((int) ((fourByteValue >> 8) & 0xFF));
-			write((int) (fourByteValue & 0xFF));
+			write((byte) symbol,
+			      (byte) ((fourByteValue >> 24) & 0xFF),
+			      (byte) ((fourByteValue >> 16) & 0xFF),
+			      (byte) ((fourByteValue >> 8) & 0xFF),
+			      (byte) (fourByteValue & 0xFF));
 		} else if (length.compareTo(new BigInteger("18446744073709551616")) == -1) {
 			symbol |= AdditionalInformation.EIGHT_BYTES.getValue();
-			write(symbol);
 			BigInteger mask = BigInteger.valueOf(0xFF);
-			write(length.shiftRight(56).and(mask).intValue());
-			write(length.shiftRight(48).and(mask).intValue());
-			write(length.shiftRight(40).and(mask).intValue());
-			write(length.shiftRight(32).and(mask).intValue());
-			write(length.shiftRight(24).and(mask).intValue());
-			write(length.shiftRight(16).and(mask).intValue());
-			write(length.shiftRight(8).and(mask).intValue());
-			write(length.and(mask).intValue());
+			write((byte) symbol,
+			      length.shiftRight(56).and(mask).byteValue(),
+			      length.shiftRight(48).and(mask).byteValue(),
+			      length.shiftRight(40).and(mask).byteValue(),
+			      length.shiftRight(32).and(mask).byteValue(),
+			      length.shiftRight(24).and(mask).byteValue(),
+			      length.shiftRight(16).and(mask).byteValue(),
+			      length.shiftRight(8).and(mask).byteValue(),
+			      length.and(mask).byteValue());
 		} else {
 			if (negative) {
 				encoder.encode(new Tag(3));
@@ -120,7 +120,7 @@ public abstract class AbstractEncoder<T> {
 		}
 	}
 
-	protected void write(byte[] bytes) throws CborException {
+	protected void write(byte... bytes) throws CborException {
 		try {
 			outputStream.write(bytes);
 		} catch (IOException ioException) {

--- a/src/main/java/co/nstant/in/cbor/encoder/DoublePrecisionFloatEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/DoublePrecisionFloatEncoder.java
@@ -14,16 +14,16 @@ public class DoublePrecisionFloatEncoder extends AbstractEncoder<DoublePrecision
 
 	@Override
 	public void encode(DoublePrecisionFloat dataItem) throws CborException {
-		write((7 << 5) | 27);
 		long bits = Double.doubleToRawLongBits(dataItem.getValue());
-		write((int) ((bits >> 56) & 0xFF));
-		write((int) ((bits >> 48) & 0xFF));
-		write((int) ((bits >> 40) & 0xFF));
-		write((int) ((bits >> 32) & 0xFF));
-		write((int) ((bits >> 24) & 0xFF));
-		write((int) ((bits >> 16) & 0xFF));
-		write((int) ((bits >> 8) & 0xFF));
-		write((int) ((bits >> 0) & 0xFF));
+		write((byte) ((7 << 5) | 27),
+		      (byte) ((bits >> 56) & 0xFF),
+		      (byte) ((bits >> 48) & 0xFF),
+		      (byte) ((bits >> 40) & 0xFF),
+		      (byte) ((bits >> 32) & 0xFF),
+		      (byte) ((bits >> 24) & 0xFF),
+		      (byte) ((bits >> 16) & 0xFF),
+		      (byte) ((bits >> 8) & 0xFF),
+		      (byte) ((bits >> 0) & 0xFF));
 	}
 
 }

--- a/src/main/java/co/nstant/in/cbor/encoder/HalfPrecisionFloatEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/HalfPrecisionFloatEncoder.java
@@ -14,10 +14,10 @@ public class HalfPrecisionFloatEncoder extends AbstractEncoder<HalfPrecisionFloa
 
 	@Override
 	public void encode(HalfPrecisionFloat dataItem) throws CborException {
-		write((7 << 5) | 25);
 		int bits = fromFloat(dataItem.getValue());
-		write((bits >> 8) & 0xFF);
-		write((bits >> 0) & 0xFF);
+		write((byte) ((7 << 5) | 25),
+		      (byte) ((bits >> 8) & 0xFF),
+		      (byte) ((bits >> 0) & 0xFF));
 	}
 
 	/**

--- a/src/main/java/co/nstant/in/cbor/encoder/SinglePrecisionFloatEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/SinglePrecisionFloatEncoder.java
@@ -14,12 +14,12 @@ public class SinglePrecisionFloatEncoder extends AbstractEncoder<SinglePrecision
 
 	@Override
 	public void encode(SinglePrecisionFloat dataItem) throws CborException {
-		write((7 << 5) | 26);
 		int bits = Float.floatToRawIntBits(dataItem.getValue());
-		write((bits >> 24) & 0xFF);
-		write((bits >> 16) & 0xFF);
-		write((bits >> 8) & 0xFF);
-		write((bits >> 0) & 0xFF);
+		write((byte) ((7 << 5) | 26),
+		      (byte) ((bits >> 24) & 0xFF),
+		      (byte) ((bits >> 16) & 0xFF),
+		      (byte) ((bits >> 8) & 0xFF),
+		      (byte) ((bits >> 0) & 0xFF));
 	}
 
 }

--- a/src/main/java/co/nstant/in/cbor/encoder/SpecialEncoder.java
+++ b/src/main/java/co/nstant/in/cbor/encoder/SpecialEncoder.java
@@ -72,8 +72,8 @@ public class SpecialEncoder extends AbstractEncoder<Special> {
                 throw new CborException("Wrong data item type");
             }
             SimpleValue simpleValueNextByte = (SimpleValue) dataItem;
-            write((7 << 5) | 24);
-            write(simpleValueNextByte.getValue());
+			write((byte) ((7 << 5) | 24),
+			      (byte) simpleValueNextByte.getValue());
             break;
         }
     }

--- a/src/main/java/co/nstant/in/cbor/model/Array.java
+++ b/src/main/java/co/nstant/in/cbor/model/Array.java
@@ -13,6 +13,11 @@ public class Array extends ChunkableDataItem {
         objects = new ArrayList<>();
     }
 
+    public Array(int initialCapacity) {
+        super(MajorType.ARRAY);
+        objects = new ArrayList<>(initialCapacity);
+    }
+
     public Array add(DataItem object) {
         objects.add(object);
         return this;

--- a/src/test/java/co/nstant/in/cbor/decoder/CborDecoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/decoder/CborDecoderTest.java
@@ -213,8 +213,9 @@ public class CborDecoderTest {
         decoder.setMaxPreallocationSize(1024);
         try {
             decoder.decode();
+            fail("Should have failed with unexpected end of stream exception");
         } catch (CborException e) {
-            // Expected without limit
+            // Expected with limit
         }
     }
 }


### PR DESCRIPTION
This PR includes the following changes:
- Reading and writing of CBOR types with known length is done with a single read/write operation instead of each byte individually. Large string types exceeding 4KB in size are read in 4KB chunks. This increases throughput reading/writing from/to unbuffered streams and reduces the overhead due to less method invocations.
- Decoding of types with fixed length always pre-allocated exactly the specified length in bytes. When CBOR is parsed from unsafe sources (e.g. user input), this approach allows a Denial of Service by crafting CBOR with very large length values, resulting in allocation of excessive memory. This change introduces the method setMaxPreallocationSize in CborDecoder, allowing implementers to specify a sane maximum length they expect to receive. Types exceeding this length will still be decoded, although the ByteArrayOutputStream will have to perform array re-allocation. I explicitly did not set a default limit as I would like to discuss this first, maybe a value of 10MB is a reasonable trade-off between security and (default) decoding speed.