### PR TITLE
Fix #147, add Automatic-Module-Name manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,18 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.2</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>co.nstant.in.cbor</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>3.2.1</version>
 				<executions>


### PR DESCRIPTION
Configures the `maven-jar-plugin` to add an `Automatic-Module-Name` entry that ensures that cbor-java has a consistent name when automatically converted to a Java 9 module. This prevents warning messages when using cbor-java in JPMS projects.