### PR TITLE
Sort canonical map keys by unsigned byte value

### DIFF
--- a/src/main/java/co/nstant/in/cbor/CborOutputStream.java
+++ b/src/main/java/co/nstant/in/cbor/CborOutputStream.java
@@ -197,10 +197,15 @@ class CborOutputStream extends OutputStream {
                     return 1;
                 }
                 for (int i = 0; i < o1.length; i++) {
-                    if (o1[i] < o2[i]) {
+                    // Byte-wise lexical order is unsigned; Java's byte is signed,
+                    // so compare the unsigned values or keys with a byte >= 0x80
+                    // would sort before keys with smaller bytes.
+                    int b1 = o1[i] & 0xFF;
+                    int b2 = o2[i] & 0xFF;
+                    if (b1 < b2) {
                         return -1;
                     }
-                    if (o1[i] > o2[i]) {
+                    if (b1 > b2) {
                         return 1;
                     }
                 }

--- a/src/test/java/co/nstant/in/cbor/encoder/MapEncoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/encoder/MapEncoderTest.java
@@ -1,12 +1,18 @@
 package co.nstant.in.cbor.encoder;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.util.List;
 
 import org.junit.Test;
 
 import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborEncoder;
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.UnicodeString;
 
 public class MapEncoderTest {
 
@@ -15,6 +21,22 @@ public class MapEncoderTest {
         List<DataItem> dataItems = new CborBuilder().addMap().put(1, true).put(".", true).put(3, true).put("..", true)
             .put(2, true).put("...", true).end().build();
         CborEncoder.encodeToBytes(dataItems);
+    }
+
+    @Test
+    public void shouldSortCanonicalKeysByUnsignedByteValue() throws CborException {
+        // Two equal-length byte-string keys, h'01' and h'ff'. Canonical order
+        // is by unsigned byte value, so h'01' must be emitted before h'ff'.
+        // A signed byte comparison would order 0xff (-1) before 0x01.
+        Map map = new Map();
+        map.put(new ByteString(new byte[] { (byte) 0xff }), new UnicodeString("B"));
+        map.put(new ByteString(new byte[] { 0x01 }), new UnicodeString("A"));
+        byte[] bytes = CborEncoder.encodeToBytes(map);
+        assertArrayEquals(new byte[] {
+            (byte) 0xa2,
+            0x41, 0x01, 0x61, 0x41,         // h'01' : "A"
+            0x41, (byte) 0xff, 0x61, 0x42   // h'ff' : "B"
+        }, bytes);
     }
 
 }


### PR DESCRIPTION
## The bug

`CborOutputStream.writeCanonicalMap` sorts map keys with a comparator whose tie-break loops over the key bytes using Java's **signed** `byte`:

```java
if (o1[i] < o2[i]) { return -1; }
if (o1[i] > o2[i]) { return 1; }
```

Java's `byte` is signed (−128…127), so any byte ≥ `0x80` compares as negative. `0xff` (−1) therefore sorts *before* `0x01` (1) — the reverse of the byte-wise lexical order the method's own Javadoc specifies:

> If two keys have the same length, the one with the lower value in (byte-wise) lexical order sorts earlier.

That order is unsigned, and it's what both RFC 7049 §3.9 (the profile this method implements) and RFC 8949 §4.2 require.

### Impact
Any canonical map containing a key whose encoding has a byte ≥ `0x80` is emitted in the wrong order — most obviously byte-string keys, but also text-string/number keys with high bytes. The result is non-canonical CBOR, which defeats the purpose of the canonical encoder: peers that re-canonicalize will disagree, and anything hashing or signing the bytes (COSE, CWT, WebAuthn, etc.) gets a different digest.

Concretely, `{h'01': "A", h'ff': "B"}` currently encodes as:

```
a2 41 ff 61 42 41 01 61 41      # h'ff' first — wrong
```

instead of

```
a2 41 01 61 41 41 ff 61 42      # h'01' first — correct
```

## The fix

Compare the unsigned byte values (`o1[i] & 0xFF`). One-liner per byte; the length-first rule and everything else are unchanged.

## Verification

- Added `MapEncoderTest.shouldSortCanonicalKeysByUnsignedByteValue`, which pins the `{h'01', h'ff'}` ordering. It **fails on the current code** (`expected:<1> but was:<-1>`) and passes with the fix.
- Full suite green with the fix: **326 tests, 0 failures**.
