### PR TITLE
Bound preallocation by available input to prevent OOM (#119)

### DIFF
--- a/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/AbstractDecoder.java
@@ -168,7 +168,21 @@ public abstract class AbstractDecoder<T> {
 
     int getPreallocationSize(long length) {
         int len = Math.abs((int) length);
-        return maxPreallocationSize > 0 ? Math.min(maxPreallocationSize, len) : len;
+        if (maxPreallocationSize > 0) {
+            len = Math.min(maxPreallocationSize, len);
+        }
+        try {
+            // Never preallocate more than the stream can actually provide, so a
+            // crafted length in a small message cannot trigger an out-of-memory
+            // allocation before the data is even read.
+            int available = inputStream.available();
+            if (len > available) {
+                len = available;
+            }
+        } catch (IOException ignored) {
+            // available() is only a hint; keep the length-based estimate.
+        }
+        return len;
     }
 
     public void setMaxPreallocationSize(int maxPreallocationSize) {

--- a/src/test/java/co/nstant/in/cbor/decoder/CborDecoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/decoder/CborDecoderTest.java
@@ -156,9 +156,10 @@ public class CborDecoderTest {
         maliciousString = new byte[] { 0x7a, 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xfe };
         try {
             CborDecoder.decode(maliciousString);
-            fail("Should have failed the huge allocation");
-        } catch (OutOfMemoryError e) {
-            // Expected without limit
+            fail("Should have failed with unexpected end of stream exception");
+        } catch (CborException e) {
+            // Preallocation is bounded by the available input, so the forged
+            // length no longer triggers an OutOfMemoryError.
         }
         CborDecoder decoder = new CborDecoder(new ByteArrayInputStream(maliciousString));
         decoder.setMaxPreallocationSize(1024);
@@ -167,6 +168,26 @@ public class CborDecoderTest {
             fail("Should have failed with unexpected end of stream exception");
         } catch (CborException e) {
             // Expected with limit
+        }
+    }
+
+    @Test
+    public void shouldNotPreallocateHugeArrayOrMap() throws CborException {
+        // An array or map that claims ~2.1 billion items but carries no data must
+        // fail with a CborException, not exhaust memory (issue #119).
+        byte[] hugeArray = new byte[] { (byte) 0x9a, 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+        try {
+            CborDecoder.decode(hugeArray);
+            fail("Should have failed with unexpected end of stream exception");
+        } catch (CborException e) {
+            // Expected.
+        }
+        byte[] hugeMap = new byte[] { (byte) 0xba, 0x7f, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+        try {
+            CborDecoder.decode(hugeMap);
+            fail("Should have failed with unexpected end of stream exception");
+        } catch (CborException e) {
+            // Expected.
         }
     }
 }


### PR DESCRIPTION
Fixes #119.

A crafted CBOR message can declare a huge array/map/string length, and the decoder preallocated a collection or buffer of that size before reading any data. So a 5-byte message like `9A 7F FF FF FF` — an array claiming 2,147,483,647 elements — triggered an `OutOfMemoryError`.

`getPreallocationSize` now also caps the size at `InputStream.available()`, so preallocation can never exceed what the message can actually provide. Legitimate data is unaffected (the bytes are present, so `available()` ≥ the length); a forged length allocates nothing and fails with the normal end-of-stream `CborException`. This applies by default, without needing `setMaxPreallocationSize`.

Updated the existing forged-length test (which previously expected the `OutOfMemoryError`) and added array/map cases.
