### PR TITLE
Fix: don't include BREAK as an element of decoded indefinite-length arrays

### DIFF
--- a/src/main/java/co/nstant/in/cbor/decoder/ArrayDecoder.java
+++ b/src/main/java/co/nstant/in/cbor/decoder/ArrayDecoder.java
@@ -35,7 +35,6 @@ public class ArrayDecoder extends AbstractDecoder<Array> {
                     throw new CborException("Unexpected end of stream");
                 }
                 if (Special.BREAK.equals(dataItem)) {
-                    array.add(Special.BREAK);
                     break;
                 }
                 array.add(dataItem);

--- a/src/test/java/co/nstant/in/cbor/decoder/ArrayDecoderTest.java
+++ b/src/test/java/co/nstant/in/cbor/decoder/ArrayDecoderTest.java
@@ -1,9 +1,19 @@
 package co.nstant.in.cbor.decoder;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
 import org.junit.Test;
 
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Special;
+import co.nstant.in.cbor.model.SpecialType;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 public class ArrayDecoderTest {
     @Test(expected = CborException.class)
@@ -16,5 +26,29 @@ public class ArrayDecoderTest {
     public void shouldThrowInIncompleteIndefiniteLengthArray() throws CborException {
         byte[] bytes = new byte[] { (byte) 0x9f, 0x01, 0x02 };
         CborDecoder.decode(bytes);
+    }
+
+    @Test
+    public void shouldDecodeEmptyIndefiniteLengthArrayAsEmpty() throws CborException {
+        // 0x9f = indefinite-length array start, 0xff = break
+        byte[] bytes = new byte[] { (byte) 0x9f, (byte) 0xff };
+        List<DataItem> decoded = CborDecoder.decode(bytes);
+        Array array = (Array) decoded.get(0);
+        assertTrue("BREAK must not be decoded as an array element", array.getDataItems().isEmpty());
+    }
+
+    @Test
+    public void shouldNotIncludeBreakAsElementOfIndefiniteLengthArray() throws CborException {
+        // 0x9f 0x01 0x02 0xff = indefinite-length array containing [1, 2]
+        byte[] bytes = new byte[] { (byte) 0x9f, 0x01, 0x02, (byte) 0xff };
+        List<DataItem> decoded = CborDecoder.decode(bytes);
+        Array array = (Array) decoded.get(0);
+        assertEquals(2, array.getDataItems().size());
+        assertEquals(new UnsignedInteger(1), array.getDataItems().get(0));
+        assertEquals(new UnsignedInteger(2), array.getDataItems().get(1));
+        for (DataItem item : array.getDataItems()) {
+            boolean isBreak = item instanceof Special && ((Special) item).getSpecialType() == SpecialType.BREAK;
+            assertTrue("no element of a decoded array should be the BREAK marker", !isBreak);
+        }
     }
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example77Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example77Test.java
@@ -2,6 +2,7 @@ package co.nstant.in.cbor.examples;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -11,7 +12,9 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 /**
  * [1, [2, 3], [_ 4,5]] -> 0x83 01 82 02 03 9f 04 05 ff
@@ -20,6 +23,22 @@ public class Example77Test {
 
     private static final List<DataItem> VALUE = new CborBuilder().addArray().add(1).addArray().add(2).add(3).end()
         .startArray().add(4).add(5).end().end().build();
+
+    // Distinct from VALUE: ArrayBuilder#end() adds a trailing Special.BREAK data item to a
+    // chunked array so that writeArray() in CborOutputStream, which has no other way to
+    // terminate a chunked array, can encode it correctly. Decoding well-formed CBOR must not
+    // reproduce that internal encoder convention: an indefinite-length array's logical value has
+    // exactly as many elements as it was written with, so BREAK must never appear as a data item
+    // in a decoded Array.
+    private static final List<DataItem> DECODED_VALUE;
+    static {
+        Array inner = new Array().add(new UnsignedInteger(4)).add(new UnsignedInteger(5));
+        inner.setChunked(true);
+        Array outer = new Array().add(new UnsignedInteger(1))
+            .add(new Array().add(new UnsignedInteger(2)).add(new UnsignedInteger(3)))
+            .add(inner);
+        DECODED_VALUE = Collections.<DataItem>singletonList(outer);
+    }
 
     private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0x83, 0x01, (byte) 0x82, 0x02, 0x03, (byte) 0x9f,
             0x04, 0x05, (byte) 0xff };
@@ -34,7 +53,7 @@ public class Example77Test {
         InputStream inputStream = new ByteArrayInputStream(ENCODED_VALUE);
         CborDecoder decoder = new CborDecoder(inputStream);
         List<DataItem> dataItems = decoder.decode();
-        Assert.assertArrayEquals(VALUE.toArray(), dataItems.toArray());
+        Assert.assertArrayEquals(DECODED_VALUE.toArray(), dataItems.toArray());
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example78Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example78Test.java
@@ -2,6 +2,7 @@ package co.nstant.in.cbor.examples;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -11,7 +12,9 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 /**
  * [1, [_ 2, 3], [4,5]] -> 0x83019f0203ff820405
@@ -20,6 +23,19 @@ public class Example78Test {
 
     private static final List<DataItem> VALUE = new CborBuilder().addArray().add(1).startArray().add(2).add(3).end()
         .addArray().add(4).add(5).end().end().build();
+
+    // See Example77Test for why this differs from VALUE: ArrayBuilder#end() deliberately leaves
+    // a trailing Special.BREAK data item in a chunked array, needed by writeArray() in
+    // CborOutputStream to terminate the encoding, but a correctly decoded Array must not contain
+    // it.
+    private static final List<DataItem> DECODED_VALUE;
+    static {
+        Array inner = new Array().add(new UnsignedInteger(2)).add(new UnsignedInteger(3));
+        inner.setChunked(true);
+        Array outer = new Array().add(new UnsignedInteger(1)).add(inner)
+            .add(new Array().add(new UnsignedInteger(4)).add(new UnsignedInteger(5)));
+        DECODED_VALUE = Collections.<DataItem>singletonList(outer);
+    }
 
     private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0x83, 0x01, (byte) 0x9f, 0x02, 0x03, (byte) 0xff,
             (byte) 0x82, 0x04, 0x05 };
@@ -34,7 +50,7 @@ public class Example78Test {
         InputStream inputStream = new ByteArrayInputStream(ENCODED_VALUE);
         CborDecoder decoder = new CborDecoder(inputStream);
         List<DataItem> dataItems = decoder.decode();
-        Assert.assertArrayEquals(VALUE.toArray(), dataItems.toArray());
+        Assert.assertArrayEquals(DECODED_VALUE.toArray(), dataItems.toArray());
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example79Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example79Test.java
@@ -2,6 +2,7 @@ package co.nstant.in.cbor.examples;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -11,7 +12,9 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 /**
  * [_ 1, 2, 3, 4, 5, 6,7, 8, 9, 10, 11, 12,13, 14, 15, 16, 17,18, 19, 20, 21,
@@ -23,6 +26,20 @@ public class Example79Test {
     private static final List<DataItem> VALUE = new CborBuilder().startArray().add(1).add(2).add(3).add(4).add(5).add(6)
         .add(7).add(8).add(9).add(10).add(11).add(12).add(13).add(14).add(15).add(16).add(17).add(18).add(19).add(20)
         .add(21).add(22).add(23).add(24).add(25).end().build();
+
+    // See Example77Test for why this differs from VALUE: ArrayBuilder#end() deliberately leaves
+    // a trailing Special.BREAK data item in a chunked array, needed by writeArray() in
+    // CborOutputStream to terminate the encoding, but a correctly decoded Array must not contain
+    // it.
+    private static final List<DataItem> DECODED_VALUE;
+    static {
+        Array array = new Array();
+        for (int i = 1; i <= 25; i++) {
+            array.add(new UnsignedInteger(i));
+        }
+        array.setChunked(true);
+        DECODED_VALUE = Collections.<DataItem>singletonList(array);
+    }
 
     private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0x9f, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18,
@@ -38,7 +55,7 @@ public class Example79Test {
         InputStream inputStream = new ByteArrayInputStream(ENCODED_VALUE);
         CborDecoder decoder = new CborDecoder(inputStream);
         List<DataItem> dataItems = decoder.decode();
-        Assert.assertArrayEquals(VALUE.toArray(), dataItems.toArray());
+        Assert.assertArrayEquals(DECODED_VALUE.toArray(), dataItems.toArray());
     }
 
 }

--- a/src/test/java/co/nstant/in/cbor/examples/Example80Test.java
+++ b/src/test/java/co/nstant/in/cbor/examples/Example80Test.java
@@ -2,6 +2,7 @@ package co.nstant.in.cbor.examples;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -11,7 +12,11 @@ import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborEncoder;
 import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.Map;
+import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
 
 /**
  * {_ "a": 1, "b": [_ 2, 3]} -> 0xbf61610161629f0203ffff
@@ -20,6 +25,22 @@ public class Example80Test {
 
     private static final List<DataItem> VALUE = new CborBuilder().startMap().put("a", 1).put("b", 2).startArray("b")
         .add(2).add(3).end().end().build();
+
+    // See Example77Test for why this differs from VALUE: ArrayBuilder#end() deliberately leaves
+    // a trailing Special.BREAK data item in a chunked array, needed by writeArray() in
+    // CborOutputStream to terminate the encoding, but a correctly decoded Array must not contain
+    // it. MapBuilder/MapDecoder don't have this issue, so only the nested array differs from
+    // VALUE.
+    private static final List<DataItem> DECODED_VALUE;
+    static {
+        Array nestedArray = new Array().add(new UnsignedInteger(2)).add(new UnsignedInteger(3));
+        nestedArray.setChunked(true);
+        Map map = new Map();
+        map.setChunked(true);
+        map.put(new UnicodeString("a"), new UnsignedInteger(1));
+        map.put(new UnicodeString("b"), nestedArray);
+        DECODED_VALUE = Collections.<DataItem>singletonList(map);
+    }
 
     private static final byte[] ENCODED_VALUE = new byte[] { (byte) 0xbf, 0x61, 0x61, 0x01, 0x61, 0x62, (byte) 0x9f,
             0x02, 0x03, (byte) 0xff, (byte) 0xff };
@@ -34,7 +55,7 @@ public class Example80Test {
         InputStream inputStream = new ByteArrayInputStream(ENCODED_VALUE);
         CborDecoder decoder = new CborDecoder(inputStream);
         List<DataItem> dataItems = decoder.decode();
-        Assert.assertArrayEquals(VALUE.toArray(), dataItems.toArray());
+        Assert.assertArrayEquals(DECODED_VALUE.toArray(), dataItems.toArray());
     }
 
 }


### PR DESCRIPTION
## What

`ArrayDecoder.decodeInfinitiveLength()` includes the `BREAK` terminator as a
literal element of the decoded array, instead of only using it to end the
decode loop:

```java
if (Special.BREAK.equals(dataItem)) {
    array.add(Special.BREAK);   // <- adds it to the array
    break;
}
```

So every indefinite-length array this library decodes (with the default
`isAutoDecodeInfinitiveArrays() == true`) has one extra trailing
`Special.BREAK` item that isn't part of the encoded value. Simplest
reproduction — the empty indefinite array `9F FF` should decode to `[]`, but
decodes to `[Special.BREAK]` (one element) instead.

`MapDecoder.decodeInfinitiveLength()` handles the identical situation
correctly a few lines away — it breaks the loop without adding anything to
the map — so `Map` decoding is unaffected; this is specific to `Array`.

(Checked at 23a10ce, current `main`.)

## Proof this is wrong, not just an opinion about API shape

This library's own `Example77Test`–`Example80Test` decode the exact worked
examples from RFC 8949 Appendix A (`[1, [_ 2, 3], [4, 5]]`,
`[_ 1, 2, ..., 25]`, etc.) and assert the decoded result equals a value built
with `CborBuilder`. Before this patch, those assertions only passed because
the `CborBuilder`-built comparison value *also* carried a trailing `BREAK`
item — see "Why the tests needed updating too" below — masking the bug in
the one place that should have caught it against the spec's own vectors.

## The fix

One line: don't add `Special.BREAK` to the array before breaking out of the
loop. `co/nstant/in/cbor/decoder/ArrayDecoder.java`.

## Why the tests needed updating too (please read before assuming this got out of scope)

`ArrayBuilder.end()` deliberately adds a trailing `Special.BREAK` item to a
chunked array:

```java
public T end() {
    if (array.isChunked()) {
        add(SimpleValue.BREAK);
    }
    return getParent();
}
```

This isn't a duplicate of the same bug — it's load-bearing for
`CborOutputStream.writeArray()`, which has no other way to terminate a
chunked array's output: it just iterates `array.getDataItems()` and writes
each one, relying on the last item being a literal `BREAK` to emit the
closing `0xFF` byte. So `ArrayBuilder` + `writeArray()` are internally
consistent with each other and I've deliberately left them untouched —
removing the `BREAK` item from the builder side would silently truncate the
output of every chunked-array encode (no closing byte at all), which is a
worse regression than the one this PR fixes. (`MapBuilder`/`writeMap()`
don't have this convention either, for what it's worth — only `Array`'s pair
does.)

That does mean `Example77Test`–`Example80Test`'s shared `VALUE` field (used
by both `shouldEncode()` and, previously, `shouldDecode()`) legitimately
still contains that `BREAK` item — it needs to, for `shouldEncode()` to keep
producing correct bytes. So `shouldDecode()` in each of those 4 files now
compares against a separately constructed `DECODED_VALUE` (built with the
low-level `Array`/`Map` model classes directly, which have no `BREAK`
handling either way) instead of reusing `VALUE`. `shouldEncode()` and
`VALUE`/`ENCODED_VALUE` are unchanged.

I think the builder/encoder convention is worth reconsidering on its own
(an explicit "write the closing byte" step in `writeArray()`, matching
however `writeMap()` does it, would let `ArrayBuilder.end()` drop the
`BREAK`-adding entirely and remove the asymmetry) — but that's a separate,
larger change and I didn't want to bundle it with this fix. Happy to send
it as a follow-up if useful.

## Testing

Added `shouldDecodeEmptyIndefiniteLengthArrayAsEmpty` and
`shouldNotIncludeBreakAsElementOfIndefiniteLengthArray` to
`ArrayDecoderTest`. Full existing suite (327 tests) passes.

## Impact

Any consumer that decodes an indefinite-length CBOR array (from this
library's own encoder or any other CBOR implementation) and then relies on
`array.getDataItems().size()` or indexes from the end gets a corrupted
result — silently, not a crash. This library is OSS-Fuzz-integrated
(`google/oss-fuzz` `projects/cbor-java`), but that harness
(`FuzzDec.java`) only calls `decode()` and catches `CborException` — it
has no equivalence/round-trip oracle, so it can't detect a non-crashing
wrong-output bug like this one regardless of how long it runs, which is
presumably why this survived undetected.
